### PR TITLE
Fixing time format

### DIFF
--- a/dripline/constants.go
+++ b/dripline/constants.go
@@ -8,7 +8,7 @@
 package dripline
 
 // Time format
-const TimeFormat = "2006-01-02T22:04:05Z"
+const TimeFormat = "2006-01-02T15:04:05Z"
 
 // Project 8 Wire Protocol Standards
 type MsgCodeT uint64
@@ -50,4 +50,3 @@ const (
 	RCErrDB          MsgCodeT = 400
 	RCErrUnhandled   MsgCodeT = 999
 )
-


### PR DESCRIPTION
Golang time documentation is confusing, and we are using the wrong time format.  When they say:
```
Format returns a textual representation of the time value formatted according to layout, which defines the format by showing how the reference time, defined to be

  Mon Jan 2 15:04:05 -0700 MST 2006
```

The correct format is `const TimeFormat = "2006-01-02T15:04:05Z"`.  The old version resulted in every timestamp being fixed at 22h (with date, min, and sec all correct).

Tested on claude and zeppelin with diopsid.